### PR TITLE
デプロイ用の環境設定（mysql）

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: chat-space_production
-  username: chat-space
-  password: <%= ENV['CHAT-SPACE_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# what
mysql設定を本番環境に合わせるよう変更
# why
本番環境でunicorn起動の際に、nysqlへの接続が行えず停止するため